### PR TITLE
Modified test exclude the svgs from A11y_DOM_04:Links must have non-e…

### DIFF
--- a/a11y.js
+++ b/a11y.js
@@ -339,7 +339,7 @@ window.$A11y = {
         _getComputedStyle : function(element) {
             var defaultView, style;
             defaultView = document.defaultView || window;
-            if (defaultView.getComputedStyle) {
+            if (defaultView.getComputedStyle && element instanceof Element)  {
                 style = document.defaultView.getComputedStyle(element, null);
             }
 
@@ -518,7 +518,7 @@ window.$A11y = {
 
             // special class that hides the element far off screen,
             // so it's accessible to screenreaders but not visible
-            if(hiddenTextClass && element.className && element.className.indexOf(hiddenTextClass) > -1) {
+            if(hiddenTextClass && element.className && element.className.indexOf && element.className.indexOf(hiddenTextClass) > -1) {
                 isVisible = false;
             }
 
@@ -797,7 +797,9 @@ window.$A11y = {
                 for(var i = 0; i < anchors.length; i++) {
                     anchor = anchors[i];
                     // check that the anchor contains text or an image with alt text
-                    if($A11y.util._hasEmptyText(anchor) && !$A11y.util._elementContainsImageWithNonEmptyAlt(anchor)) {
+                    if($A11y.util._hasEmptyText(anchor) 
+                        && !$A11y.util._elementContainsImageWithNonEmptyAlt(anchor) 
+                        && $A11y.util._getElementsByTagName("svg", anchor).length == 0) {
                         errorArray.push(anchor);
                     }
                 }
@@ -822,6 +824,10 @@ window.$A11y = {
                         }
                     }
 
+                    if(element.nodeName.toLowerCase() == "a" 
+                        && $A11y.util._getElementsByTagName("svg", element).length != 0 ){
+                        return;
+                    }
                     // if this is a text node
                     if(element.nodeType == Node.TEXT_NODE || element.nodeType == 3) {
                         // check that it has text in it and is visible in viewport
@@ -829,7 +835,7 @@ window.$A11y = {
                             parentNode = element.parentNode;
                             if(parentNode
                                && parentNode.nodeName.toUpperCase() !== "SCRIPT" 
-                               && parentNode.nodeName.toUpperCase() !== "STYLE" 
+                               && parentNode.nodeName.toUpperCase() !== "STYLE"
                                && $A11y.util._isElementVisible(parentNode)) {
                                 textNodes.push(parentNode);
                             }
@@ -840,7 +846,7 @@ window.$A11y = {
                             getTextNodes(element.childNodes[i]);
                         }
                     }
-                }
+                }//End of getTextNodes
 
                 getTextNodes(domElem);
                 for(var i = 0; i < textNodes.length; i++) {


### PR DESCRIPTION
Modified tests:
1) check that we are looking at DOM elements and not #document (issue with checking iframes)
2) indexOf function for strings exist (SVG's don't have this function through the className attribute because they return SVGStrings instead of String Element)
3) Checking to make sure that we are only looking at anchors that don't contain SVGs when we are checking for empty text
4) added Text to signify the end of a inner function to make it more clear
